### PR TITLE
stoat example

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,9 +1,9 @@
 name: E2E
 
-on:
-  push:
-    branches: [main]
-  pull_request:
+#on:
+#  push:
+#    branches: [main]
+#  pull_request:
 
 jobs:
   install:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,3 +27,8 @@ jobs:
         uses: docker/setup-buildx-action@v2
       - name: Run E2E tests
         run: make e2e
+
+      - name: Run Stoat Action
+        uses: stoat-dev/stoat-action@v0
+        if: always()
+

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -14,3 +14,8 @@ jobs:
       - run: curl -X POST "${{ env.WEBSITE_CLOUDFLARE_DEPLOY_HOOK }}" -v
         env:
           WEBSITE_CLOUDFLARE_DEPLOY_HOOK: ${{ secrets.WEBSITE_CLOUDFLARE_DEPLOY_HOOK }}
+
+      - name: Run Stoat Action
+        uses: stoat-dev/stoat-action@v0
+        if: always()
+

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,11 +1,11 @@
 name: Trigger example changes
 
-on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'examples/**'
+#on:
+#  push:
+#    branches:
+#      - main
+#    paths:
+#      - 'examples/**'
 
 jobs:
   deploy-website:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -33,7 +33,6 @@ jobs:
         run: |
           echo '{ "issues": ${{ steps.issues.outputs.value }} }' > ${{ matrix.os }}-issues.json
           cp golangci.html ${{ matrix.os }}-golangci.html
-          cat ${{ matrix.os }}-issues.json
       - name: Run Stoat Action
         uses: stoat-dev/stoat-action@v0
         if: always()
@@ -53,6 +52,10 @@ jobs:
         run: |
           go install gotest.tools/gotestsum@latest
           gotestsum --junitfile junit.xml -- -race -coverprofile=coverage.out ./...
+      - name: Write Test Status
+        if: always()
+        run: |
+          echo '{ "success": ${{ success() }} }' > ${{ matrix.os }}-status.json
       - name: Generate Test Report HTML
         id: xunit-viewer
         uses: AutoModality/action-xunit-viewer@v1

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Write Issue Count & Copy File
         if: always()
         run: |
-          echo "{ "issues": ${{ steps.version.outputs.value }} }" > ${{ matrix.os }}-issues.json
+          echo '{ "issues": ${{ steps.version.outputs.value }} }' > ${{ matrix.os }}-issues.json
           cp golangci.html ${{ matrix.os }}-golangci.html
       - name: Run Stoat Action
         uses: stoat-dev/stoat-action@v0
@@ -60,7 +60,7 @@ jobs:
           output: ${{ matrix.os }}-junit.html
       - name: Generate Coverage HTML
         if: always()
-        run: go tool cover -o ${{ matrix.os }}-coverage.html -html=coverage.out
+        run: go tool cover -o coverage.html -html=coverage.out
       - name: Generate Coverage Treemap
         if: always()
         run: |

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -39,9 +39,11 @@ jobs:
         with:
           go-version: 1.18
       - name: Test
-        run: go test -race ./...
-
+        run: go test -coverprofile coverage.out -race ./...
+      - name: Generate Coverage Treemap
+        run: |
+          go install github.com/nikolaydubina/go-cover-treemap@latest
+          go-cover-treemap -h 240 -coverprofile coverage.out > coverage.svg
       - name: Run Stoat Action
         uses: stoat-dev/stoat-action@v0
         if: always()
-

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -22,6 +22,11 @@ jobs:
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.50.1
           ./bin/golangci-lint run --verbose
+
+      - name: Run Stoat Action
+        uses: stoat-dev/stoat-action@v0
+        if: always()
+
   test:
     strategy:
       matrix:
@@ -35,3 +40,8 @@ jobs:
           go-version: 1.18
       - name: Test
         run: go test -race ./...
+
+      - name: Run Stoat Action
+        uses: stoat-dev/stoat-action@v0
+        if: always()
+

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -60,12 +60,11 @@ jobs:
         if: ${{ failure() }}
         run: |
           echo '{ "success": false }' > ${{ matrix.os }}-status.json
-      - name: Generate Test Report HTML
-        id: xunit-viewer
-        uses: AutoModality/action-xunit-viewer@v1
+      - uses: actions/setup-python@v4
         with:
-          results: junit.xml
-          output: ${{ matrix.os }}-junit.html
+          python-version: '3.10'
+      - run: pip3 install junit2html
+      - run: junit2html junit.xml ${{ matrix.os }}-junit.html
       - name: Generate Coverage HTML
         if: always()
         run: go tool cover -o coverage.html -html=coverage.out

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -22,7 +22,14 @@ jobs:
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.50.1
           ./bin/golangci-lint run --verbose
-
+      - name: Extract Issue Count
+        id: issues
+        uses: sergeysova/jq-action@v2
+        with:
+          cmd: 'jq ".Issues | length" golangci.json -r'
+      - name: Write Issue Count
+        run: |
+          echo "{ "issues": ${{ steps.version.outputs.value }} }" > issues.json
       - name: Run Stoat Action
         uses: stoat-dev/stoat-action@v0
         if: always()
@@ -39,10 +46,17 @@ jobs:
         with:
           go-version: 1.18
       - name: Test
-        run: go test -coverprofile coverage.out -race ./...
+        run: gotestsum --jsonfile tests.jsonl --junitfile junit.xml -- -race -coverprofile=coverage.out ./...
+      - name: Generate Test Result HTML
+        if: always()
+        run: |
+          go get -u github.com/vakenbolt/go-test-report/
+          cat tests.jsonl | go-test-report -o tests.html
       - name: Generate Coverage HTML
+        if: always()
         run: go tool cover -o coverage.html -html=coverage.out
       - name: Generate Coverage Treemap
+        if: always()
         run: |
           go install github.com/nikolaydubina/go-cover-treemap@latest
           go-cover-treemap -h 240 -padding 0 -coverprofile coverage.out > coverage.svg

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -61,10 +61,13 @@ jobs:
         run: |
           echo '{ "success": false }' > ${{ matrix.os }}-status.json
       - uses: actions/setup-python@v4
+        if: always()
         with:
           python-version: '3.10'
       - run: pip3 install junit2html
+        if: always()
       - run: junit2html junit.xml ${{ matrix.os }}-junit.html
+        if: always()
       - name: Generate Coverage HTML
         if: always()
         run: go tool cover -o coverage.html -html=coverage.out

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Write Issue Count & Copy File
         if: always()
         run: |
-          echo '{ "issues": ${{ steps.version.outputs.value }} }' > ${{ matrix.os }}-issues.json
+          echo '{ "issues": ${{ steps.issues.outputs.value }} }' > ${{ matrix.os }}-issues.json
           cp golangci.html ${{ matrix.os }}-golangci.html
           cat ${{ matrix.os }}-issues.json
       - name: Run Stoat Action

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -52,10 +52,14 @@ jobs:
         run: |
           go install gotest.tools/gotestsum@latest
           gotestsum --junitfile junit.xml -- -race -coverprofile=coverage.out ./...
-      - name: Write Test Status
-        if: always()
+      - name: Write Success
+        if: ${{ success() }}
         run: |
-          echo '{ "success": ${{ success() }} }' > ${{ matrix.os }}-status.json
+          echo '{ "success": true }' > ${{ matrix.os }}-status.json
+      - name: Write Failure
+        if: ${{ failure() }}
+        run: |
+          echo '{ "success": false }' > ${{ matrix.os }}-status.json
       - name: Generate Test Report HTML
         id: xunit-viewer
         uses: AutoModality/action-xunit-viewer@v1

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -33,6 +33,7 @@ jobs:
         run: |
           echo '{ "issues": ${{ steps.version.outputs.value }} }' > ${{ matrix.os }}-issues.json
           cp golangci.html ${{ matrix.os }}-golangci.html
+          cat ${{ matrix.os }}-issues.json
       - name: Run Stoat Action
         uses: stoat-dev/stoat-action@v0
         if: always()

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -46,12 +46,15 @@ jobs:
         with:
           go-version: 1.18
       - name: Test
-        run: gotestsum --jsonfile tests.jsonl --junitfile junit.xml -- -race -coverprofile=coverage.out ./...
-      - name: Generate Test Result HTML
-        if: always()
         run: |
-          go get -u github.com/vakenbolt/go-test-report/
-          cat tests.jsonl | go-test-report -o tests.html
+          go install gotest.tools/gotestsum@latest
+          gotestsum --jsonfile tests.jsonl --junitfile junit.xml -- -race -coverprofile=coverage.out ./...
+      - name: Generate Test Report HTML
+        id: xunit-viewer
+        uses: AutoModality/action-xunit-viewer@v1
+        with:
+          results: junit.xml
+          output: junit.html
       - name: Generate Coverage HTML
         if: always()
         run: go tool cover -o coverage.html -html=coverage.out

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -10,7 +10,7 @@ jobs:
     name: lint
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -27,9 +27,10 @@ jobs:
         uses: sergeysova/jq-action@v2
         with:
           cmd: 'jq ".Issues | length" golangci.json -r'
-      - name: Write Issue Count
+      - name: Write Issue Count & Copy FIle
         run: |
-          echo "{ "issues": ${{ steps.version.outputs.value }} }" > issues.json
+          echo "{ "issues": ${{ steps.version.outputs.value }} }" > ${{ matrix.os }}-issues.json
+          cp golangci.html ${{ matrix.os }}-golangci.html
       - name: Run Stoat Action
         uses: stoat-dev/stoat-action@v0
         if: always()
@@ -37,7 +38,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -48,16 +49,16 @@ jobs:
       - name: Test
         run: |
           go install gotest.tools/gotestsum@latest
-          gotestsum --jsonfile tests.jsonl --junitfile junit.xml -- -race -coverprofile=coverage.out ./...
+          gotestsum --junitfile junit.xml -- -race -coverprofile=coverage.out ./...
       - name: Generate Test Report HTML
         id: xunit-viewer
         uses: AutoModality/action-xunit-viewer@v1
         with:
           results: junit.xml
-          output: junit.html
+          output: ${{ matrix.os }}-junit.html
       - name: Generate Coverage HTML
         if: always()
-        run: go tool cover -o coverage.html -html=coverage.out
+        run: go tool cover -o ${{ matrix.os }}-coverage.html -html=coverage.out
       - name: Generate Coverage Treemap
         if: always()
         run: |

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -23,11 +23,13 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.50.1
           ./bin/golangci-lint run --verbose
       - name: Extract Issue Count
+        if: always()
         id: issues
         uses: sergeysova/jq-action@v2
         with:
           cmd: 'jq ".Issues | length" golangci.json -r'
-      - name: Write Issue Count & Copy FIle
+      - name: Write Issue Count & Copy File
+        if: always()
         run: |
           echo "{ "issues": ${{ steps.version.outputs.value }} }" > ${{ matrix.os }}-issues.json
           cp golangci.html ${{ matrix.os }}-golangci.html

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -40,6 +40,8 @@ jobs:
           go-version: 1.18
       - name: Test
         run: go test -coverprofile coverage.out -race ./...
+      - name: Generate Coverage HTML
+        run: go tool cover -o coverage.html -html=coverage.out
       - name: Generate Coverage Treemap
         run: |
           go install github.com/nikolaydubina/go-cover-treemap@latest

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Test
         run: |
           go install gotest.tools/gotestsum@latest
-          gotestsum --junitfile junit.xml -- -race -coverprofile=coverage.out ./...
+          gotestsum --jsonfile tests.jsonl -- -race -coverprofile=coverage.out ./...
       - name: Write Success
         if: ${{ success() }}
         run: |
@@ -60,14 +60,11 @@ jobs:
         if: ${{ failure() }}
         run: |
           echo '{ "success": false }' > ${{ matrix.os }}-status.json
-      - uses: actions/setup-python@v4
+      - name: Generate Test HTML
         if: always()
-        with:
-          python-version: '3.10'
-      - run: pip3 install junit2html
-        if: always()
-      - run: junit2html junit.xml ${{ matrix.os }}-junit.html
-        if: always()
+        run: |
+          go install github.com/vakenbolt/go-test-report@latest
+          cat tests.jsonl | go-test-report -o ${{ matrix.os }}-junit.html
       - name: Generate Coverage HTML
         if: always()
         run: go tool cover -o coverage.html -html=coverage.out

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Generate Coverage Treemap
         run: |
           go install github.com/nikolaydubina/go-cover-treemap@latest
-          go-cover-treemap -h 240 -coverprofile coverage.out > coverage.svg
+          go-cover-treemap -h 240 -padding 0 -coverprofile coverage.out > coverage.svg
       - name: Run Stoat Action
         uses: stoat-dev/stoat-action@v0
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
-on:
-  push:
-    tags:
-      - "v*"
+#on:
+#  push:
+#    tags:
+#      - "v*"
 
 jobs:
   goreleaser:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,11 @@ jobs:
           args: release --rm-dist --debug
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Stoat Action
+        uses: stoat-dev/stoat-action@v0
+        if: always()
+
   npm:
     runs-on: ubuntu-latest
     needs: [goreleaser]
@@ -67,4 +72,9 @@ jobs:
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Run Stoat Action
+        uses: stoat-dev/stoat-action@v0
+        if: always()
+
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,7 @@ coverage.html
 golangci.html
 golangci.json
 bin
-tests.log
+tests.jsonl
+tests.html
+issues.json
+junit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pkg/devserver/index.html
 .idea
 coverage.out
 coverage.svg
+coverage.html

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ pkg/devserver/index.html
 coverage.out
 coverage.svg
 coverage.html
+golangci.html
+golangci.json
+bin

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ coverage.html
 golangci.html
 golangci.json
 bin
+tests.log

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ testfns/
 
 main
 pkg/devserver/index.html
+
+.DS_Store
+.idea
+coverage.out
+coverage.svg

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tests.jsonl
 tests.html
 issues.json
 junit.xml
+junit.html

--- a/.golangci.json
+++ b/.golangci.json
@@ -5,7 +5,16 @@
         ],
         "timeout": "10m"
     },
+    "output": {
+        "format": "colored-line-number:stdout,html:golangci.html,json:golangci.json"
+    },
+    "linters": {
+        "enable": ["misspell"]
+    },
     "linters-settings": {
+        "misspell": {
+            "ignore-words": []
+        },
         "staticcheck": {
             "checks": [
                 "all",

--- a/.stoat/comment.hbs
+++ b/.stoat/comment.hbs
@@ -1,7 +1,23 @@
-{{#if plugins.json.linter.value.Issues.length}}
-[![linter](https://img.shields.io/badge/linter-{{ plugins.json.linter.value.Issues.length }}%20issues-red.svg?style=flat)]({{ plugins.static_hosting.linter.link }})
-{{ else }}
-[![linter](https://img.shields.io/badge/linter<{{ plugins.static_hosting.linter.sha }}>-passing-brightgreen.svg?style=flat)]({{ plugins.static_hosting.linter.link }})
-{{/if}}
+### Build Results
 
+<table>
+    <tr>
+        <td>Linter</td>
+        <td>
+            <a href="{{ plugins.static_hosting.linter.link }}">
+                {{#if plugins.json.linter.value.Issues.length}}
+                    <img src="https://img.shields.io/badge/{{ plugins.static_hosting.linter.sha }}-{{ plugins.json.linter.value.Issues.length }}%20issues-red.svg?style=flat" alt="{{ plugins.static_hosting.linter.sha }} failing">
+                {{ else }}
+                    <img src="https://img.shields.io/badge/{{ plugins.static_hosting.linter.sha }}-passing-brightgreen.svg?style=flat" alt="{{ plugins.static_hosting.linter.sha }} passing">
+                {{/if}}
+            </a>
+        </td>
+    </tr>
+    <tr>
+        <td>Tests</td>
+        <td>Row 2 Cell 2</td>
+    </tr>
+</table>
+
+### Test Coverage
 [![test coverage]({{ plugins.static_hosting.coverage_image.link }})]({{ plugins.static_hosting.coverage_html.link }})

--- a/.stoat/comment.hbs
+++ b/.stoat/comment.hbs
@@ -8,7 +8,7 @@
         </td>
         <td>
             <a href="{{ plugins.static_hosting.linter.link }}">
-                {{#if plugins.json.linter.value.Issues.length}}
+                {{#if plugins.json.issues.value.issues}}
                     <img src="https://img.shields.io/badge/{{ plugins.json.linter.value.Issues.length }}%20issues-red.svg?style=flat" alt="{{ plugins.static_hosting.linter.sha }} failing">
                 {{ else }}
                     <img src="https://img.shields.io/badge/passing-brightgreen.svg?style=flat" alt="{{ plugins.static_hosting.linter.sha }} passing">

--- a/.stoat/comment.hbs
+++ b/.stoat/comment.hbs
@@ -31,3 +31,5 @@
 
 ### Test Coverage
 [![test coverage]({{ plugins.static_hosting.coverage_image.link }})]({{ plugins.static_hosting.coverage_html.link }})
+
+{{{ views.plugins.job_runtime.github.chart }}}

--- a/.stoat/comment.hbs
+++ b/.stoat/comment.hbs
@@ -4,24 +4,28 @@
     <tr>
         <td><strong>Linter</strong></td>
         <td>
-            {{ plugins.static_hosting.linter.sha }}
-        </td>
-        <td>
-            <a href="{{ plugins.static_hosting.linter.link }}">
-                {{#if plugins.json.issues.value.issues}}
-                    <img src="https://img.shields.io/badge/{{ plugins.json.linter.value.Issues.length }}%20issues-red.svg?style=flat" alt="{{ plugins.static_hosting.linter.sha }} failing">
+            <a href="{{ plugins.static_hosting.ubuntu_linter.link }}">
+                {{#if plugins.json.ubuntu_issues.value.issues}}
+                    <img src="https://img.shields.io/badge/ubuntu-{{ plugins.json.ubuntu_linter.value.Issues.length }}%20issues-red.svg?style=flat" alt="{{ plugins.static_hosting.ubuntu_linter.sha }} failing">
                 {{ else }}
-                    <img src="https://img.shields.io/badge/passing-brightgreen.svg?style=flat" alt="{{ plugins.static_hosting.linter.sha }} passing">
+                    <img src="https://img.shields.io/badge/ubuntu-passing-brightgreen.svg?style=flat" alt="{{ plugins.static_hosting.ubuntu_linter.sha }} passing">
                 {{/if}}
             </a>
+        </td>
+        <td>
+            {{ plugins.static_hosting.ubuntu_linter.sha }}
         </td>
     </tr>
     <tr>
         <td><strong>Tests</strong></td>
         <td>
-            {{ plugins.static_hosting.linter.sha }}
+            <a href="{{ plugins.static_hosting.ubuntu_test_html.link }}">
+                <img src="https://img.shields.io/badge/ubuntu-{{ plugins.static_hosting.ubuntu_test_html.status }}-white.svg?style=flat" alt="{{ plugins.static_hosting.ubuntu_test_html.sha }} {{ plugins.static_hosting.ubuntu_test_html.status }}">
+            </a>
         </td>
-        <td>todo</td>
+        <td>
+            {{ plugins.static_hosting.ubuntu_linter.sha }}
+        </td>
     </tr>
 </table>
 

--- a/.stoat/comment.hbs
+++ b/.stoat/comment.hbs
@@ -18,7 +18,11 @@
         <td><strong>Tests</strong></td>
         <td>
             <a href="{{ plugins.static_hosting.ubuntu_test_html.link }}">
-                <img src="https://img.shields.io/badge/ubuntu-results%20{{ plugins.static_hosting.ubuntu_test_html.status }}-lightcyan.svg?style=flat" alt="{{ plugins.static_hosting.ubuntu_test_html.sha }} {{ plugins.static_hosting.ubuntu_test_html.status }}">
+                {{#if plugins.json.status.value.success}}
+                    <img src="https://img.shields.io/badge/ubuntu-passing-brightgreen.svg?style=flat" alt="{{ plugins.static_hosting.ubuntu_linter.sha }} passing">
+                {{ else }}
+                    <img src="https://img.shields.io/badge/ubuntu-failed-red.svg?style=flat" alt="{{ plugins.static_hosting.ubuntu_linter.sha }} failing">
+                {{/if}}
             </a>
         </td>
         <td>{{ plugins.static_hosting.ubuntu_linter.sha }}</td>

--- a/.stoat/comment.hbs
+++ b/.stoat/comment.hbs
@@ -2,7 +2,7 @@
 
 <table>
     <tr>
-        <td><strong>Go Linter</strong></td>
+        <td><strong>Linter</strong></td>
         <td>
             {{ plugins.static_hosting.linter.sha }}
         </td>
@@ -17,7 +17,7 @@
         </td>
     </tr>
     <tr>
-        <td><strong>Go Tests</strong></td>
+        <td><strong>Tests</strong></td>
         <td>
             {{ plugins.static_hosting.linter.sha }}
         </td>

--- a/.stoat/comment.hbs
+++ b/.stoat/comment.hbs
@@ -1,0 +1,1 @@
+![test coverage]({{ plugins.static_hosting.coverage.link }})

--- a/.stoat/comment.hbs
+++ b/.stoat/comment.hbs
@@ -2,7 +2,7 @@
 
 <table>
     <tr>
-        <td>Linter</td>
+        <td><strong>Go Linter</strong></td>
         <td>
             {{ plugins.static_hosting.linter.sha }}
         </td>
@@ -17,7 +17,7 @@
         </td>
     </tr>
     <tr>
-        <td>Tests</td>
+        <td><strong>Go Tests</strong></td>
         <td>
             {{ plugins.static_hosting.linter.sha }}
         </td>

--- a/.stoat/comment.hbs
+++ b/.stoat/comment.hbs
@@ -6,7 +6,7 @@
         <td>
             <a href="{{ plugins.static_hosting.ubuntu_linter.link }}">
                 {{#if plugins.json.ubuntu_issues.value.issues}}
-                    <img src="https://img.shields.io/badge/ubuntu-{{ plugins.json.ubuntu_linter.value.Issues.length }}%20issues-red.svg?style=flat" alt="{{ plugins.static_hosting.ubuntu_linter.sha }} failing">
+                    <img src="https://img.shields.io/badge/ubuntu-{{ plugins.json.ubuntu_issues.value.issues }}%20issues-red.svg?style=flat" alt="{{ plugins.static_hosting.ubuntu_linter.sha }} failing">
                 {{ else }}
                     <img src="https://img.shields.io/badge/ubuntu-passing-brightgreen.svg?style=flat" alt="{{ plugins.static_hosting.ubuntu_linter.sha }} passing">
                 {{/if}}
@@ -18,7 +18,7 @@
         <td><strong>Tests</strong></td>
         <td>
             <a href="{{ plugins.static_hosting.ubuntu_test_html.link }}">
-                <img src="https://img.shields.io/badge/ubuntu-results%20{{ plugins.static_hosting.ubuntu_test_html.status }}-lightgray.svg?style=flat" alt="{{ plugins.static_hosting.ubuntu_test_html.sha }} {{ plugins.static_hosting.ubuntu_test_html.status }}">
+                <img src="https://img.shields.io/badge/ubuntu-results%20{{ plugins.static_hosting.ubuntu_test_html.status }}-lightcyan.svg?style=flat" alt="{{ plugins.static_hosting.ubuntu_test_html.sha }} {{ plugins.static_hosting.ubuntu_test_html.status }}">
             </a>
         </td>
         <td>{{ plugins.static_hosting.ubuntu_linter.sha }}</td>

--- a/.stoat/comment.hbs
+++ b/.stoat/comment.hbs
@@ -4,18 +4,24 @@
     <tr>
         <td>Linter</td>
         <td>
+            {{ plugins.static_hosting.linter.sha }}
+        </td>
+        <td>
             <a href="{{ plugins.static_hosting.linter.link }}">
                 {{#if plugins.json.linter.value.Issues.length}}
-                    <img src="https://img.shields.io/badge/{{ plugins.static_hosting.linter.sha }}-{{ plugins.json.linter.value.Issues.length }}%20issues-red.svg?style=flat" alt="{{ plugins.static_hosting.linter.sha }} failing">
+                    <img src="https://img.shields.io/badge/{{ plugins.json.linter.value.Issues.length }}%20issues-red.svg?style=flat" alt="{{ plugins.static_hosting.linter.sha }} failing">
                 {{ else }}
-                    <img src="https://img.shields.io/badge/{{ plugins.static_hosting.linter.sha }}-passing-brightgreen.svg?style=flat" alt="{{ plugins.static_hosting.linter.sha }} passing">
+                    <img src="https://img.shields.io/badge/passing-brightgreen.svg?style=flat" alt="{{ plugins.static_hosting.linter.sha }} passing">
                 {{/if}}
             </a>
         </td>
     </tr>
     <tr>
         <td>Tests</td>
-        <td>Row 2 Cell 2</td>
+        <td>
+            {{ plugins.static_hosting.linter.sha }}
+        </td>
+        <td>todo</td>
     </tr>
 </table>
 

--- a/.stoat/comment.hbs
+++ b/.stoat/comment.hbs
@@ -1,1 +1,7 @@
+{{#if plugins.json.linter.value.Issues.length}}
+[![linter](https://img.shields.io/badge/linter-{{ plugins.json.linter.value.Issues.length }}%20issues-red.svg?style=flat)]({{ plugins.static_hosting.linter.link }})
+{{ else }}
+[![linter](https://img.shields.io/badge/linter<{{ plugins.static_hosting.linter.sha }}>-passing-brightgreen.svg?style=flat)]({{ plugins.static_hosting.linter.link }})
+{{/if}}
+
 [![test coverage]({{ plugins.static_hosting.coverage_image.link }})]({{ plugins.static_hosting.coverage_html.link }})

--- a/.stoat/comment.hbs
+++ b/.stoat/comment.hbs
@@ -18,7 +18,7 @@
         <td><strong>Tests</strong></td>
         <td>
             <a href="{{ plugins.static_hosting.ubuntu_test_html.link }}">
-                <img src="https://img.shields.io/badge/ubuntu-{{ plugins.static_hosting.ubuntu_test_html.status }}-white.svg?style=flat" alt="{{ plugins.static_hosting.ubuntu_test_html.sha }} {{ plugins.static_hosting.ubuntu_test_html.status }}">
+                <img src="https://img.shields.io/badge/ubuntu-results%20{{ plugins.static_hosting.ubuntu_test_html.status }}-lightgray.svg?style=flat" alt="{{ plugins.static_hosting.ubuntu_test_html.sha }} {{ plugins.static_hosting.ubuntu_test_html.status }}">
             </a>
         </td>
         <td>{{ plugins.static_hosting.ubuntu_linter.sha }}</td>

--- a/.stoat/comment.hbs
+++ b/.stoat/comment.hbs
@@ -1,1 +1,1 @@
-![test coverage]({{ plugins.static_hosting.coverage.link }})
+[![test coverage]({{ plugins.static_hosting.coverage_image.link }})]({{ plugins.static_hosting.coverage_html.link }})

--- a/.stoat/comment.hbs
+++ b/.stoat/comment.hbs
@@ -12,9 +12,7 @@
                 {{/if}}
             </a>
         </td>
-        <td>
-            {{ plugins.static_hosting.ubuntu_linter.sha }}
-        </td>
+        <td>{{ plugins.static_hosting.ubuntu_linter.sha }}</td>
     </tr>
     <tr>
         <td><strong>Tests</strong></td>
@@ -23,9 +21,7 @@
                 <img src="https://img.shields.io/badge/ubuntu-{{ plugins.static_hosting.ubuntu_test_html.status }}-white.svg?style=flat" alt="{{ plugins.static_hosting.ubuntu_test_html.sha }} {{ plugins.static_hosting.ubuntu_test_html.status }}">
             </a>
         </td>
-        <td>
-            {{ plugins.static_hosting.ubuntu_linter.sha }}
-        </td>
+        <td>{{ plugins.static_hosting.ubuntu_linter.sha }}</td>
     </tr>
 </table>
 

--- a/.stoat/config.yaml
+++ b/.stoat/config.yaml
@@ -1,0 +1,11 @@
+---
+version: 1
+enabled: true
+plugins:
+  job_runtime:
+    enabled: true
+#  static_hosting:
+#    your_unique_id:
+#      metadata:
+#        name: "Name of artifact you're hosting, such as Code Coverage Report"
+#      path: path/from/git/root/to/directory/to/host

--- a/.stoat/config.yaml
+++ b/.stoat/config.yaml
@@ -5,8 +5,13 @@ comment_template_file: ".stoat/comment.hbs"
 plugins:
   job_runtime:
     enabled: true
+  json:
+    linter:
+      path: golangci.json
   static_hosting:
     coverage_image:
       path: coverage.svg
     coverage_html:
       path: coverage.html
+    linter:
+      path: golangci.html

--- a/.stoat/config.yaml
+++ b/.stoat/config.yaml
@@ -1,11 +1,10 @@
 ---
 version: 1
 enabled: true
+comment_template_file: ".stoat/comment.hbs"
 plugins:
   job_runtime:
     enabled: true
-#  static_hosting:
-#    your_unique_id:
-#      metadata:
-#        name: "Name of artifact you're hosting, such as Code Coverage Report"
-#      path: path/from/git/root/to/directory/to/host
+  static_hosting:
+    coverage:
+      path: coverage.svg

--- a/.stoat/config.yaml
+++ b/.stoat/config.yaml
@@ -6,14 +6,20 @@ plugins:
   job_runtime:
     enabled: true
   json:
-    issues:
-      path: issues.json
+    ubuntu_issues:
+      path: ubuntu-latest-issues.json
+    windows_issues:
+      path: windows-latest-issues.json
   static_hosting:
     coverage_image:
       path: coverage.svg
     coverage_html:
       path: coverage.html
-    test_html:
-      path: junit.html
-    linter:
-      path: golangci.html
+    ubuntu_linter:
+      path: ubuntu-latest-golangci.html
+    windows_linter:
+      path: windows-latest-golangci.html
+    ubuntu_test_html:
+      path: ubuntu-latest-junit.html
+    windows_test_html:
+      path: windows-latest-junit.html

--- a/.stoat/config.yaml
+++ b/.stoat/config.yaml
@@ -6,5 +6,7 @@ plugins:
   job_runtime:
     enabled: true
   static_hosting:
-    coverage:
+    coverage_image:
       path: coverage.svg
+    coverage_html:
+      path: coverage.html

--- a/.stoat/config.yaml
+++ b/.stoat/config.yaml
@@ -8,8 +8,8 @@ plugins:
   json:
     ubuntu_issues:
       path: ubuntu-latest-issues.json
-    windows_issues:
-      path: windows-latest-issues.json
+    status:
+      path: ubuntu-latest-status.json
   static_hosting:
     coverage_image:
       path: coverage.svg
@@ -17,9 +17,5 @@ plugins:
       path: coverage.html
     ubuntu_linter:
       path: ubuntu-latest-golangci.html
-    windows_linter:
-      path: windows-latest-golangci.html
     ubuntu_test_html:
       path: ubuntu-latest-junit.html
-    windows_test_html:
-      path: windows-latest-junit.html

--- a/.stoat/config.yaml
+++ b/.stoat/config.yaml
@@ -6,8 +6,8 @@ plugins:
   job_runtime:
     enabled: true
   json:
-    linter:
-      path: golangci.json
+    issues:
+      path: issues.json
   static_hosting:
     coverage_image:
       path: coverage.svg

--- a/.stoat/config.yaml
+++ b/.stoat/config.yaml
@@ -13,5 +13,7 @@ plugins:
       path: coverage.svg
     coverage_html:
       path: coverage.html
+    test_html:
+      path: junit.html
     linter:
       path: golangci.html

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -64,7 +64,7 @@ func TestQueueEnqueueItem(t *testing.T) {
 		require.Equal(t, QueuePartition{
 			WorkflowID: item.WorkflowID,
 			Priority:   testPriority,
-			AtS:        start.Unix(),
+			AtS:        start.Unix() + 1,
 		}, qp)
 
 		// Ensure that the zscore did not change.

--- a/tests/fns/event-trigger-expression/run.go
+++ b/tests/fns/event-trigger-expression/run.go
@@ -80,20 +80,20 @@ func Do(ctx context.Context) testdsl.Chain {
 		// # Third test: success
 		//
 		// OK is false, cart items match.
-		testdsl.SendEvent(event.Event{
-			Name: "test/trigger-expression",
-			Data: map[string]any{
-				"ok": true,
-				"cart_items": []map[string]any{
-					{
-						"price": 999,
-					},
-					{
-						"price": 100,
-					},
-				},
-			},
-		}),
+// 		testdsl.SendEvent(event.Event{
+// 			Name: "test/trigger-expression",
+// 			Data: map[string]any{
+// 				"ok": true,
+// 				"cart_items": []map[string]any{
+// 					{
+// 						"price": 999,
+// 					},
+// 					{
+// 						"price": 100,
+// 					},
+// 				},
+// 			},
+// 		}),
 		testdsl.RequireOutputWithin("received message", 500*time.Millisecond),
 		// Ensure runner consumes event.
 		testdsl.RequireLogFieldsWithin(map[string]any{
@@ -104,7 +104,7 @@ func Do(ctx context.Context) testdsl.Chain {
 		testdsl.RequireLogFieldsWithin(map[string]any{
 			"caller":   "runner",
 			"function": "event-trigger-expression",
-			"message":  "initializing fn INTENTIONALLY FAIL",
+			"message":  "initializing fn",
 		}, testdsl.DefaultDuration),
 	}
 }

--- a/tests/fns/event-trigger-expression/run.go
+++ b/tests/fns/event-trigger-expression/run.go
@@ -80,20 +80,20 @@ func Do(ctx context.Context) testdsl.Chain {
 		// # Third test: success
 		//
 		// OK is false, cart items match.
-// 		testdsl.SendEvent(event.Event{
-// 			Name: "test/trigger-expression",
-// 			Data: map[string]any{
-// 				"ok": true,
-// 				"cart_items": []map[string]any{
-// 					{
-// 						"price": 999,
-// 					},
-// 					{
-// 						"price": 100,
-// 					},
-// 				},
-// 			},
-// 		}),
+		testdsl.SendEvent(event.Event{
+			Name: "test/trigger-expression",
+			Data: map[string]any{
+				"ok": true,
+				"cart_items": []map[string]any{
+					{
+						"price": 999,
+					},
+					{
+						"price": 100,
+					},
+				},
+			},
+		}),
 		testdsl.RequireOutputWithin("received message", 500*time.Millisecond),
 		// Ensure runner consumes event.
 		testdsl.RequireLogFieldsWithin(map[string]any{

--- a/tests/fns/event-trigger-expression/run.go
+++ b/tests/fns/event-trigger-expression/run.go
@@ -104,7 +104,7 @@ func Do(ctx context.Context) testdsl.Chain {
 		testdsl.RequireLogFieldsWithin(map[string]any{
 			"caller":   "runner",
 			"function": "event-trigger-expression",
-			"message":  "initializing fn",
+			"message":  "initializing fn INTENTIONALLY FAIL",
 		}, testdsl.DefaultDuration),
 	}
 }


### PR DESCRIPTION
Here's an example PR that only applies to the ubuntu build, but is meant to demonstrate some of [Stoat](stoat.dev)'s features on a Go project.

1. Ability to access linting results with a single click (I added `misspelled` as a linter so it would have failures to look at here)
2. Ability to access test results in a UI. (see upper right hand corner of linked reports labeled with `[F]`. I also added test failures so it could show up)
3. You can also click on the test coverage diagram to see more specific breakdowns.
4. Job runtime charts. We will also be able to track arbitrary metrics here in the future (build artifact sizes, test coverage %, other kpis).